### PR TITLE
chore: updated dependencies, replaced JCenter, patched R.id issue

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+- @azure Rule - Use Azure Best Practices: When generating code for Azure, running terminal commands for Azure, or performing operations related to Azure, invoke your `get_azure_best_practices` tool if available.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,10 +2,12 @@ apply plugin: 'com.android.application'
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral() // Add this
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.51.0'
     }
 }
 
@@ -29,7 +31,7 @@ android {
     } else  {
         android.buildTypes.release.signingConfig = null
     }
-    compileSdkVersion 27
+    compileSdkVersion 35
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +42,7 @@ android {
     }
     defaultConfig {
         applicationId "ca.rmen.android.scrumchatter"
+        namespace "ca.rmen.android.scrumchatter"
         versionCode 10606
         versionName "1.6.6"
         minSdkVersion 14
@@ -51,6 +54,9 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
         }
+    }
+    buildFeatures {
+        buildConfig true
     }
     return true;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,17 +2,19 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral() // Add this
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:8.9.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral() // Add this
+        gradlePluginPortal()
     }
     configurations.all {
         resolutionStrategy.force "com.android.support:appcompat-v7:${supportLibVersion}", "com.android.support:cardview-v7:${supportLibVersion}", "com.android.support:design:${supportLibVersion}", "com.android.support:preference-v7:${supportLibVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx2048m
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Apr 05 22:49:01 CDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Switched from deprecated JCenter to MavenCentral
- Applied gradle.properties workaround to keep R.id constants working with Gradle 8+
- Still targeting SDK 27 — upgrade pending proper refactor
- TODO: clean up switch-case logic using R.id to future-proof the code
